### PR TITLE
[MM-18008] Include channel id in edited post

### DIFF
--- a/server/plugin.go
+++ b/server/plugin.go
@@ -215,12 +215,13 @@ func (p *Plugin) handleCancel(w http.ResponseWriter, r *http.Request) {
 	_, queryString, _, _ := decodeContext(request.Context)
 
 	post := model.Post{
-		Id:       request.PostId,
-		Type:     model.POST_EPHEMERAL,
-		Message:  `Cancelled giphy: "` + queryString + `"`,
-		UserId:   request.UserId,
-		CreateAt: model.GetMillis(),
-		UpdateAt: model.GetMillis(),
+		Id:        request.PostId,
+		ChannelId: request.ChannelId,
+		Type:      model.POST_EPHEMERAL,
+		Message:   `Cancelled giphy: "` + queryString + `"`,
+		UserId:    request.UserId,
+		CreateAt:  model.GetMillis(),
+		UpdateAt:  model.GetMillis(),
 	}
 	// post.AddProp("from_webhook", "true")
 


### PR DESCRIPTION
#### Summary

When the user presses cancel on their ephemeral giphy post, the giphy plugin backend does not include the post's `channel_id` when updating the post to `Cancelled giphy: "(search term)"`. When the user clicks the x to remove the post, the webapp crashes because the `channel_id` is not present.

This PR ensures the `channel_id` is used when updating the post.



#### Ticket Link

https://mattermost.atlassian.net/browse/MM-18008